### PR TITLE
add 'dm_menu_section_label' twig function 

### DIFF
--- a/Twig/MenuExtension.php
+++ b/Twig/MenuExtension.php
@@ -12,9 +12,6 @@ class MenuExtension extends \Twig_Extension {
      */
     private $menuFactory;
 
-    /** @var array */
-    private $cache = array();
-
     /**
      * @var \Twig_Environment
      */
@@ -49,7 +46,7 @@ class MenuExtension extends \Twig_Extension {
      */
     public function render($name, array $options = array())
     {
-        $menu = $this->getMenuByName($name);
+        $menu = $this->menuFactory->create($name);
 
         $defaultOptions = array(
             'collapse' => false,
@@ -69,21 +66,8 @@ class MenuExtension extends \Twig_Extension {
      */
     public function getMenuSectionLabel($name)
     {
-        $menu = $this->getMenuByName($name);
+        $menu = $this->menuFactory->create($name);
         return $menu ? $menu->getFirstActiveChild()->getLabel() : '';
-    }
-
-    /**
-     * Cache menus by name
-     * @param $name
-     * @return mixed
-     */
-    private function getMenuByName($name)
-    {
-        if (!isset($this->cache[$name])) {
-            $this->cache[$name] = $this->menuFactory->create($name);
-        }
-        return $this->cache[$name];
     }
 
     /**


### PR DESCRIPTION
Sometimes its nice to print the name of the currently action menu section in other places / templates:
- Add 'dm_menu_section_label' twig function to get the label of first-active-child menu item. 
- Cache result of menu-factory-create in case menu-label (or menu) is needed multiple times per request.
